### PR TITLE
Fixed error in example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ pub fn main() {
 
   // Create an email to send
   let email = zeptomail.Email(
-    from: [Addressee("Mike", "mike@example.com")],
-    to: Addressee("Joe", "joe@example.com"),
+    from: Addressee("Mike", "mike@example.com"),
+    to: [Addressee("Joe", "joe@example.com")],
     reply_to: [],
     cc: [Addressee("Robert", "robert@example.com")],
     bcc: [],


### PR DESCRIPTION
In call to zeptomail.Email(), the "from" argument should not be a List, while the "to" argument should be. These were backwards in the example.